### PR TITLE
[Feat] 애플 로그인 구현

### DIFF
--- a/coachcoach/app/src/main/java/com/coachcoach/app/api/user/AuthController.java
+++ b/coachcoach/app/src/main/java/com/coachcoach/app/api/user/AuthController.java
@@ -140,4 +140,15 @@ public class AuthController {
     ) {
         return authService.naverLogin(request);
     }
+
+    /**
+     * 애플 로그인
+     */
+    @Operation(summary = "애플 로그인")
+    @PostMapping("/apple/login")
+    public LoginResponse appleLogin(
+            @RequestBody AppleLoginRequest request
+    ) {
+        return authService.appleLogin(request);
+    }
 }

--- a/coachcoach/app/src/main/resources/application.yml
+++ b/coachcoach/app/src/main/resources/application.yml
@@ -83,4 +83,10 @@ social:
     client-secret: ${NAVER_CLIENT_SECRET}
     auth-url: https://nid.naver.com/oauth2.0
     api-url: https://openapi.naver.com
+  apple:
+    team-id: ${APPLE_TEAM_ID}
+    client-id: ${APPLE_CLIENT_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY}
+    auth-url: https://appleid.apple.com/auth
 prod.url: ${PROD_URL}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/config/WebClientConfig.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/config/WebClientConfig.java
@@ -21,11 +21,15 @@ public class WebClientConfig {
     @Value("${social.naver.auth-url}")
     private String NAVER_AUTH_URL;
 
+    @Value("${social.apple.auth-url}")
+    private String APPLE_AUTH_URL;
+
     @Value("${social.kakao.api-url}")
     private String KAKAO_API_URL;
 
     @Value("${social.naver.api-url}")
     private String NAVER_API_URL;
+
 
     @Bean
     public WebClient kakaoAuthWebClient() {
@@ -55,5 +59,10 @@ public class WebClientConfig {
                 .build();
     }
 
-
+    @Bean
+    public WebClient appleAuthWebClient() {
+        return WebClient.builder()
+                .baseUrl(APPLE_AUTH_URL)
+                .build();
+    }
 }

--- a/coachcoach/user/src/main/java/com/coachcoach/user/domain/Users.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/domain/Users.java
@@ -70,6 +70,19 @@ public class Users {
                 .build();
     }
 
+    public static Users createAppleUser(String id, String sub) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return Users.builder()
+                .loginId(id)
+                .password(null)
+                .onboardingCompleted(false)
+                .createdAt(now)
+                .updatedAt(now)
+                .socialProvider("apple")
+                .socialSub(sub)
+                .build();
+    }
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();

--- a/coachcoach/user/src/main/java/com/coachcoach/user/dto/apple/AppleUserInfo.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/dto/apple/AppleUserInfo.java
@@ -1,0 +1,6 @@
+package com.coachcoach.user.dto.apple;
+
+public record AppleUserInfo(
+        String sub
+) {
+}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/dto/request/AppleLoginRequest.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/dto/request/AppleLoginRequest.java
@@ -1,0 +1,19 @@
+package com.coachcoach.user.dto.request;
+
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+
+public record AppleLoginRequest(
+        @NotBlank
+        String identityToken,
+
+        @Nullable
+        String fcmToken,
+
+        @Nullable
+        String deviceType,
+
+        @Nullable
+        String deviceId
+) {
+}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/dto/response/ApplePublicKeyResponse.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/dto/response/ApplePublicKeyResponse.java
@@ -1,0 +1,19 @@
+package com.coachcoach.user.dto.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+public record ApplePublicKeyResponse(
+        List<ApplePublicKey> keys
+) {
+    @Getter
+    public static class ApplePublicKey {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;   // RSA modulus
+        private String e;   // RSA exponent
+    }
+}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/dto/response/AppleTokenResponse.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/dto/response/AppleTokenResponse.java
@@ -1,0 +1,15 @@
+package com.coachcoach.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AppleTokenResponse(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("refresh_token")
+        String refreshToken,
+
+        @JsonProperty("token_type")
+        String tokenType
+) {
+}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/exception/SocialLoginErrorCode.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/exception/SocialLoginErrorCode.java
@@ -22,7 +22,20 @@ public enum SocialLoginErrorCode implements ErrorCode {
     NAVER_UNAUTHORIZED("SOCIAL_NAVER_003", "네이버 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
     NAVER_FORBIDDEN("SOCIAL_NAVER_005", "허용되지 않은 접근입니다.", HttpStatus.FORBIDDEN),
     NAVER_NOT_FOUND("SOCIAL_NAVER_006", "요청한 네이버 API를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    NAVER_SERVER_ERROR("SOCIAL_NAVER_009", "네이버 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    NAVER_SERVER_ERROR("SOCIAL_NAVER_009", "네이버 서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 애플 로그인
+    APPLE_UNAUTHORIZED("SOCIAL_APPLE_001", "애플 계정 인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_INVALID_TOKEN("SOCIAL_APPLE_002", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_EXPIRED_TOKEN("SOCIAL_APPLE_003", "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_INVALID_ISSUER("SOCIAL_APPLE_004", "토큰의 발급자가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_INVALID_AUDIENCE("SOCIAL_APPLE_005", "토큰의 대상이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_PUBLIC_KEY_NOT_FOUND("SOCIAL_APPLE_006", "매칭되는 애플 공개키를 찾을 수 없습니다.", HttpStatus.UNAUTHORIZED),
+    APPLE_PUBLIC_KEY_FETCH_FAILED("SOCIAL_APPLE_007", "애플 공개키 조회에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    APPLE_PUBLIC_KEY_INVALID("SOCIAL_APPLE_008", "애플 공개키 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    APPLE_NOT_LINKED("SOCIAL_APPLE_009", "애플 계정 연결이 필요합니다. 다시 로그인해주세요.", HttpStatus.BAD_REQUEST),
+    APPLE_ALREADY_LINKED("SOCIAL_APPLE_010", "이미 애플 계정이 연결된 사용자입니다.", HttpStatus.BAD_REQUEST),
+    APPLE_FORBIDDEN("SOCIAL_APPLE_011", "필수 동의 항목이 누락되었습니다. 동의 후 다시 시도해주세요.", HttpStatus.FORBIDDEN),
     ;
     private final String code;
     private final String message;

--- a/coachcoach/user/src/main/java/com/coachcoach/user/service/AppleLoginService.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/service/AppleLoginService.java
@@ -1,0 +1,258 @@
+package com.coachcoach.user.service;
+
+import com.coachcoach.common.exception.BusinessException;
+import com.coachcoach.user.dto.apple.AppleUserInfo;
+import com.coachcoach.user.dto.response.ApplePublicKeyResponse;
+import com.coachcoach.user.dto.response.AppleTokenResponse;
+import com.coachcoach.user.exception.SocialLoginErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Date;
+
+@Service
+@Slf4j
+public class AppleLoginService {
+
+    @Value("${social.apple.team-id}")
+    private String TEAM_ID;
+
+    @Value("${social.apple.client-id}")
+    private String CLIENT_ID;
+
+    @Value("${social.apple.key-id}")
+    private String KEY_ID;
+
+    @Value("${social.apple.private-key}")
+    private String PRIVATE_KEY;
+
+    private final WebClient appleAuthWebClient;
+
+    public AppleLoginService(
+            @Qualifier("appleAuthWebClient") WebClient appleAuthWebClient
+    ) {
+        this.appleAuthWebClient = appleAuthWebClient;
+    }
+
+    /**
+     * Apple 공개 키 목록 조회
+     */
+    public ApplePublicKeyResponse getApplePublicKeys() {
+        return appleAuthWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/keys")
+                        .build()
+                )
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class)
+                                .flatMap(body -> {
+                                    log.error("애플 공개 키 목록 조회 API 에러: {}", body);
+
+                                    return Mono.error(new BusinessException(SocialLoginErrorCode.APPLE_PUBLIC_KEY_FETCH_FAILED));
+                                }))
+                .bodyToMono(ApplePublicKeyResponse.class)
+                .block();
+    }
+
+    /**
+     * identity token 검증 & 사용자 정보 추출
+     */
+    public AppleUserInfo verifyAndExtract(String identityToken) {
+        String kid = extractKidFromToken(identityToken);
+
+        // 공개키 목록 조회
+        ApplePublicKeyResponse publicKeys = getApplePublicKeys();
+
+        // 공개키 검증
+        ApplePublicKeyResponse.ApplePublicKey matchedKey = publicKeys.keys().stream()
+                .filter(key -> key.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(SocialLoginErrorCode.APPLE_PUBLIC_KEY_NOT_FOUND));
+
+
+        // 공개키 객체 생성
+        PublicKey publicKey = buildPublicKey(matchedKey);
+
+        // Claims 추출
+        Claims claims = parseClaimsOrThrow(identityToken, publicKey);
+
+        // Claims 검증
+        validateClaims(claims);
+
+        return new AppleUserInfo(claims.getSubject());
+
+    }
+
+
+    /**
+     * JWT 헤더에서 kid(서명한 공개키) 추출
+     */
+    public String extractKidFromToken(String token) {
+        try {
+            String headerBase64 = token.split("\\.")[0];
+            String headerJson = new String(Base64.getUrlDecoder().decode(headerBase64));
+            ObjectMapper objectMapper = new ObjectMapper();
+            JsonNode header = objectMapper.readTree(headerJson);
+            return header.get("kid").asText();
+        } catch (Exception e) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    /**
+     * RSA PublicKey 객체 생성
+     */
+    public PublicKey buildPublicKey(ApplePublicKeyResponse.ApplePublicKey key) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());
+            byte[] eBytes = Base64.getUrlDecoder().decode(key.getE());
+
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(
+                    new BigInteger(1, nBytes),
+                    new BigInteger(1, eBytes)
+            );
+            return KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (Exception e) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_PUBLIC_KEY_INVALID);
+        }
+    }
+
+    /**
+     * 공개키 서명 검증 & Claims 파싱
+     */
+    private Claims parseClaimsOrThrow(String identityToken, PublicKey publicKey) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(identityToken)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_EXPIRED_TOKEN);
+        } catch (JwtException e) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_INVALID_TOKEN);
+        }
+    }
+
+    /**
+     * Claims 검증
+     */
+    public void validateClaims(Claims claims) {
+        if(!"https://appleid.apple.com".equals(claims.getIssuer())) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_INVALID_ISSUER);
+        }
+
+        if(!claims.getAudience().contains(CLIENT_ID)) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_INVALID_AUDIENCE);
+        }
+
+        if(claims.getExpiration().before(new Date())) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_EXPIRED_TOKEN);
+        }
+    }
+
+    /**
+     * 토큰 무효화
+     */
+    public void revoke(String authorizationCode) {
+        String accessToken = getAccessToken(authorizationCode);
+        revokeToken(accessToken);
+    }
+
+    /**
+     * revoke token
+     */
+    private void revokeToken(String accessToken) {
+        appleAuthWebClient.post()
+                .uri(uriBuilder -> uriBuilder.path("/revoke")
+                        .build()
+                )
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue("client_id=" + CLIENT_ID + "&client_secret=" + generateClientSecret() + "&token=" + accessToken + "&token_type_hint=access_token")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> response.bodyToMono(String.class)
+                        .flatMap(body -> {
+                            log.error("애플 revoke API 에러: {}", body);
+
+                            return Mono.error(new BusinessException(SocialLoginErrorCode.APPLE_UNAUTHORIZED));
+                        })
+                )
+                .bodyToMono(Void.class)
+                .block();
+    }
+
+    /**
+     * access token 발급
+     */
+    private String getAccessToken(String authorizationCode) {
+        AppleTokenResponse res = appleAuthWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/token")
+                        .build()
+                )
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .bodyValue("client_id=" + CLIENT_ID + "&client_secret=" + generateClientSecret() + "&code=" + authorizationCode + "&grant_type=authorization_code")
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class)
+                                .flatMap(body -> {
+                                    log.error("애플 Access Token 발급 API 에러: {}", body);
+
+                                    return Mono.error(new BusinessException(SocialLoginErrorCode.APPLE_UNAUTHORIZED));
+                                })
+                )
+                .bodyToMono(AppleTokenResponse.class)
+                .block();
+
+        return res.accessToken();
+    }
+
+    /**
+     * client secret JWT 생성
+     */
+    private String generateClientSecret() {
+        try {
+            byte[] keyBytes = Base64.getDecoder().decode(PRIVATE_KEY);
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+            PrivateKey signingKey = KeyFactory.getInstance("EC").generatePrivate(keySpec);
+
+            return Jwts.builder()
+                    .header().add("kid", KEY_ID).and()
+                    .issuer(TEAM_ID)
+                    .issuedAt(new Date())
+                    .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 5)) // 5분
+                    .audience().add("https://appleid.apple.com").and()
+                    .subject(CLIENT_ID)
+                    .signWith(signingKey)
+                    .compact();
+        } catch (Exception e) {
+            throw new BusinessException(SocialLoginErrorCode.APPLE_UNAUTHORIZED);
+        }
+    }
+}

--- a/coachcoach/user/src/main/java/com/coachcoach/user/service/AuthService.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/service/AuthService.java
@@ -4,6 +4,7 @@ import com.coachcoach.common.exception.BusinessException;
 import com.coachcoach.common.exception.CommonErrorCode;
 import com.coachcoach.common.security.jwt.JwtUtil;
 import com.coachcoach.user.domain.FcmToken;
+import com.coachcoach.user.dto.apple.AppleUserInfo;
 import com.coachcoach.user.dto.request.*;
 import com.coachcoach.user.dto.response.*;
 import com.coachcoach.user.domain.RefreshToken;
@@ -38,6 +39,7 @@ public class AuthService {
     private final JwtUtil jwtUtil;
     private final KakaoLoginService kakaoLoginService;
     private final NaverLoginService naverLoginService;
+    private final AppleLoginService appleLoginService;
     private final NotificationService notificationService;
 
     /**
@@ -206,6 +208,25 @@ public class AuthService {
         return usersRepository.findBySocialSubAndSocialProvider(naverId, "naver")
                 .orElseGet(() -> usersRepository.saveAndFlush(
                         Users.createNaverUser(randomLoginId(), naverId)
+                ));
+    }
+
+    // =========================================================================
+    // 애플 로그인
+    // =========================================================================
+    @Transactional(transactionManager = "transactionManager")
+    public LoginResponse appleLogin(AppleLoginRequest request) {
+        AppleUserInfo appleUserInfo = appleLoginService.verifyAndExtract(request.identityToken());
+
+        Users user = findOrCreateAppleUser(appleUserInfo.sub());
+        return issueTokensAndRespond(user, request.fcmToken(), request.deviceType(), request.deviceId());
+
+    }
+
+    private Users findOrCreateAppleUser(String sub) {
+        return usersRepository.findBySocialSubAndSocialProvider(sub, "apple")
+                .orElseGet(() -> usersRepository.saveAndFlush(
+                        Users.createAppleUser(randomLoginId(), sub)
                 ));
     }
 

--- a/coachcoach/user/src/main/java/com/coachcoach/user/service/UserService.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/service/UserService.java
@@ -38,6 +38,7 @@ public class UserService {
     private final InsightQueryApi insightQueryApi;
     private final KakaoLoginService kakaoLoginService;
     private final NaverLoginService naverLoginService;
+    private final AppleLoginService appleLoginService;
 
     /**
      * 온보딩
@@ -116,6 +117,8 @@ public class UserService {
             }
 
             naverLoginService.unlink(request.accessToken());
+        } else if("apple".equals(user.getSocialProvider())) {
+            appleLoginService.revoke(request.accessToken());
         }
     }
 

--- a/coachcoach/user/src/test/java/com/coachcoach/user/service/AppleLoginServiceTest.java
+++ b/coachcoach/user/src/test/java/com/coachcoach/user/service/AppleLoginServiceTest.java
@@ -1,0 +1,182 @@
+package com.coachcoach.user.service;
+
+import com.coachcoach.common.exception.BusinessException;
+import com.coachcoach.user.dto.response.ApplePublicKeyResponse;
+import com.coachcoach.user.exception.SocialLoginErrorCode;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+public class AppleLoginServiceTest {
+
+    @InjectMocks
+    private AppleLoginService appleLoginService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(appleLoginService, "CLIENT_ID", "com.seungwan.coachcoach");
+    }
+
+    /**
+     * extractKidFromToken (JWT 헤더에서 공개키 추출 검증)
+     */
+    @Test
+    void should_extract_kid_from_jwt_header() {
+        // given
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"RS256\",\"kid\":\"ABC123\"}".getBytes());
+        String fakeToken = header + ".payload.signature";
+
+        // when
+        String kid = appleLoginService.extractKidFromToken(fakeToken);
+
+        // then
+        assertThat(kid).isEqualTo("ABC123");
+    }
+
+    @Test
+    void should_throw_APPLE_INVALID_TOKEN_when_jwt_format_is_invalid() {
+        // given
+        String invalidToken = "invalid-token";
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.extractKidFromToken(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_INVALID_TOKEN);
+    }
+
+    @Test
+    void should_throw_APPLE_INVALID_TOKEN_when_kid_field_is_missing() {
+        // given
+        String header = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString("{\"alg\":\"RS256\"}".getBytes());
+        String fakeToken = header + ".payload.signature";
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.extractKidFromToken(fakeToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_INVALID_TOKEN);
+    }
+
+    /**
+     *  buildPublicKey (RSA 공개키 객체 생성 로직 검증)
+     */
+    @Test
+    void should_build_rsa_public_key_with_valid_n_and_e() throws NoSuchAlgorithmException {
+        // given - 실제 RSA 키쌍 생성해서 n, e 추출
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        RSAPublicKey rsaPublicKey = (RSAPublicKey) keyPair.getPublic();
+
+        String n = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(rsaPublicKey.getModulus().toByteArray());
+        String e = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(rsaPublicKey.getPublicExponent().toByteArray());
+
+        ApplePublicKeyResponse.ApplePublicKey key = mock(ApplePublicKeyResponse.ApplePublicKey.class);
+        given(key.getN()).willReturn(n);
+        given(key.getE()).willReturn(e);
+
+        // when & then
+        assertThatNoException()
+                .isThrownBy(() -> appleLoginService.buildPublicKey(key));
+    }
+
+    @Test
+    void should_throw_APPLE_PUBLIC_KEY_INVALID_when_n_is_invalid() {
+        // given
+        ApplePublicKeyResponse.ApplePublicKey key = mock(ApplePublicKeyResponse.ApplePublicKey.class);
+        given(key.getN()).willReturn("!@#$%^&*");
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.buildPublicKey(key))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_PUBLIC_KEY_INVALID);
+    }
+
+    @Test
+    void should_throw_APPLE_PUBLIC_KEY_INVALID_when_e_is_invalid() {
+        // given
+        ApplePublicKeyResponse.ApplePublicKey key = mock(ApplePublicKeyResponse.ApplePublicKey.class);
+        given(key.getN()).willReturn("valid_n");
+        given(key.getE()).willReturn("invalid_e!!!");
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.buildPublicKey(key))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_PUBLIC_KEY_INVALID);
+    }
+
+    /**
+     * validClaims
+     */
+    @Test
+    void should_pass_validation_when_claims_are_valid() {
+        // given
+        Claims claims = mock(Claims.class);
+        given(claims.getIssuer()).willReturn("https://appleid.apple.com");
+        given(claims.getAudience()).willReturn(Set.of("com.seungwan.coachcoach"));
+        given(claims.getExpiration()).willReturn(new Date(System.currentTimeMillis() + 10000));
+
+        // when & then
+        assertThatNoException()
+                .isThrownBy(() -> appleLoginService.validateClaims(claims));
+    }
+
+    @Test
+    void should_throw_APPLE_INVALID_ISSUER_when_iss_is_wrong() {
+        // given
+        Claims claims = mock(Claims.class);
+        given(claims.getIssuer()).willReturn("https://invalid.com");
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.validateClaims(claims))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_INVALID_ISSUER);
+    }
+
+    @Test
+    void should_throw_APPLE_INVALID_AUDIENCE_when_client_id_not_in_aud() {
+        // given
+        Claims claims = mock(Claims.class);
+        given(claims.getIssuer()).willReturn("https://appleid.apple.com");
+        given(claims.getAudience()).willReturn(Set.of("com.wrong.app"));
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.validateClaims(claims))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_INVALID_AUDIENCE);
+    }
+
+    @Test
+    void should_throw_APPLE_EXPIRED_TOKEN_when_token_is_expired() {
+        // given
+        Claims claims = mock(Claims.class);
+        given(claims.getIssuer()).willReturn("https://appleid.apple.com");
+        given(claims.getAudience()).willReturn(Set.of("com.seungwan.coachcoach"));
+        given(claims.getExpiration()).willReturn(new Date(System.currentTimeMillis() - 10000)); // 과거
+
+        // when & then
+        assertThatThrownBy(() -> appleLoginService.validateClaims(claims))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", SocialLoginErrorCode.APPLE_EXPIRED_TOKEN);
+    }
+}


### PR DESCRIPTION
## 📌 PR 요약
애플 로그인 구현

## 🔗 관련 이슈
- Related to #67

## ☑️ 작업 내용
- [ ] 애플 로그인 API 엔드포인트 작성
- [ ] 회원 탈퇴 로직에 apple token revoke 추가 

## 🧪 테스트 내용
- [ ] 개별 로직 테스트 완료 

## ⚠️ 영향 범위

## 📸 스크린샷 / 결과 (선택)

## 📝 리뷰 요청 사항
