### PR TITLE
[Fix] 소셜 온보딩 스토어 저장 누락 수정

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,9 +19,11 @@ jobs:
           java-version: 21
 
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/setup-buildx-action@v3
 
       - name: Check Docker
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: docker version
 
       - name: Grant execute permission for gradlew
@@ -34,10 +36,12 @@ jobs:
 
       # Quay 로그인
       - name: Login to Quay
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u bread0930 --password-stdin
 
       # 도커 이미지 빌드 & 푸시
       - name: Build & Push Docker images
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: coachcoach
         shell: bash
         run: |
@@ -51,6 +55,7 @@ jobs:
           echo "Image pushed successfully"
 
   deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/coachcoach/user/src/main/java/com/coachcoach/user/service/UserService.java
+++ b/coachcoach/user/src/main/java/com/coachcoach/user/service/UserService.java
@@ -46,7 +46,8 @@ public class UserService {
     @Transactional(transactionManager = "transactionManager")
     public void onboarding(Long userId, OnboardingRequest request) {
         Users user = usersRepository.findByUserId(userId).orElseThrow(() -> new BusinessException(UserErrorCode.NOTFOUND_USER));
-        Store store = storeRepository.findByUserId(userId).orElse(Store.create(user));
+        Store store = storeRepository.findByUserId(userId)
+                .orElseGet(() -> storeRepository.save(Store.create(user)));
 
         store.updateInformation(
                 request.name(),

--- a/coachcoach/user/src/test/java/com/coachcoach/user/service/UserServiceTest.java
+++ b/coachcoach/user/src/test/java/com/coachcoach/user/service/UserServiceTest.java
@@ -1,0 +1,97 @@
+package com.coachcoach.user.service;
+
+import com.coachcoach.common.api.CatalogQueryApi;
+import com.coachcoach.common.api.InsightQueryApi;
+import com.coachcoach.common.api.NotificationQueryApi;
+import com.coachcoach.user.domain.Store;
+import com.coachcoach.user.domain.Users;
+import com.coachcoach.user.dto.request.OnboardingRequest;
+import com.coachcoach.user.repository.RefreshTokenRepository;
+import com.coachcoach.user.repository.StoreRepository;
+import com.coachcoach.user.repository.UsersRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UsersRepository usersRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private CatalogQueryApi catalogQueryApi;
+
+    @Mock
+    private InsightQueryApi insightQueryApi;
+
+    @Mock
+    private NotificationQueryApi notificationQueryApi;
+
+    @Mock
+    private KakaoLoginService kakaoLoginService;
+
+    @Mock
+    private NaverLoginService naverLoginService;
+
+    @Mock
+    private AppleLoginService appleLoginService;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("온보딩 시 스토어가 없으면 생성 후 저장한다")
+    void onboarding_CreateStoreWhenMissing() {
+        // given
+        Long userId = 4L;
+        Users user = Users.builder()
+                .userId(userId)
+                .onboardingCompleted(false)
+                .build();
+        OnboardingRequest request = new OnboardingRequest(
+                "코치코치 카페",
+                2,
+                BigDecimal.valueOf(12000),
+                null,
+                true
+        );
+
+        given(usersRepository.findByUserId(userId)).willReturn(Optional.of(user));
+        given(storeRepository.findByUserId(userId)).willReturn(Optional.empty());
+        given(storeRepository.save(any(Store.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        userService.onboarding(userId, request);
+
+        // then
+        ArgumentCaptor<Store> storeCaptor = ArgumentCaptor.forClass(Store.class);
+        verify(storeRepository).save(storeCaptor.capture());
+        Store savedStore = storeCaptor.getValue();
+        assertThat(savedStore.getUser()).isEqualTo(user);
+        assertThat(savedStore.getName()).isEqualTo("코치코치 카페");
+        assertThat(savedStore.getEmployees()).isEqualTo(2);
+        assertThat(savedStore.getLaborCost()).isEqualByComparingTo(BigDecimal.valueOf(12000));
+        assertThat(savedStore.getIncludeWeeklyHolidayPay()).isTrue();
+        assertThat(user.getOnboardingCompleted()).isTrue();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 소셜 로그인 사용자의 온보딩 시 Store row가 없으면 `storeRepository.save(Store.create(user))`로 즉시 저장하도록 수정했습니다.
- Store 누락 상태에서 메뉴 생성이 `USER_011 스토어가 존재하지 않습니다`로 실패하던 경로를 회귀 테스트로 고정했습니다.

## 검증
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) bash ./gradlew :user:test --tests com.coachcoach.user.service.UserServiceTest --stacktrace`

## 참고
- 기존 Store가 누락된 운영 사용자 데이터는 별도 보정이 필요할 수 있습니다.
